### PR TITLE
Add tomcat-users.xml file and volume mount in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,5 @@ services:
       - db
     ports:
       - "80:8080"
+    volumes:
+      - ./tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml

--- a/tomcat-users.xml
+++ b/tomcat-users.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<tomcat-users>
+	<role rolename="manager-gui"/>
+	<user username="tomcat" password="tomcat" roles="manager-gui"/>
+</tomcat-users>


### PR DESCRIPTION
Hi,

Thanks for sharing this!

I had to had a look at the Manager app, but alas the tomcat container used doesn't seem to provide default credentials for that. So in this pull request the tomcat container has been updated to mount a volume which basically copies the tomcat-users.xml and puts it in /usr/loca/tomcat/conf/tomcat-users.xml.

Tested locally.

Cheers
Bruno