### PR TITLE
Add gitignore to prevent accidentally adding Thingworx files to the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+tw/*
+!tw/UNPACK_TW_HERE.txt


### PR DESCRIPTION
Just to make sure no one accidentally uploads the zip, war, batch scripts, etc.