### PR TITLE
Update Dockerfile.postgres

### DIFF
--- a/Dockerfile.postgres
+++ b/Dockerfile.postgres
@@ -1,4 +1,4 @@
-FROM postgres:9
+FROM postgres:9.6.5
 
 COPY /tw/install/ /twpginit/
 COPY /twpg_init.sh /docker-entrypoint-initdb.d/


### PR DESCRIPTION
FROM postgres:9 would result in psql 9.3.23 which has a compatibility issue, FROM postgres:9.6.5 works as expected